### PR TITLE
Directory creation and Default for create_viz

### DIFF
--- a/dockers/hto-adt-postprocess/src/demux_dsb.py
+++ b/dockers/hto-adt-postprocess/src/demux_dsb.py
@@ -221,7 +221,7 @@ if __name__ == "__main__":
         method=params.method,
     )
 
-    os.makedirs(params.output_dir, exist_ok=True)
+    # os.makedirs(params.output_dir, exist_ok=True)
 
     stats_file = os.path.join(params.output_dir, "stats.yml")
     write_stats(adata_result.obs, adata_result.uns["metrics"], output_file=stats_file)

--- a/dockers/hto-adt-postprocess/src/dsb.py
+++ b/dockers/hto-adt-postprocess/src/dsb.py
@@ -89,8 +89,8 @@ def parse_arguments():
         "--create-viz",
         action="store_true",
         dest="create_viz",
-        help="create visualization plot (default: True)",
-        default=True,
+        help="create visualization plot (default: False)",
+        default=False,
     )
 
     # parse arguments

--- a/dockers/hto-adt-postprocess/src/dsb.py
+++ b/dockers/hto-adt-postprocess/src/dsb.py
@@ -37,17 +37,26 @@ def dsb(
     dsb_adapted(adata_filtered, adata_raw)
 
     # Ensure the output directory exists
-    os.makedirs(os.path.dirname(path_adata_out), exist_ok=True)
+    # os.makedirs(os.path.dirname(path_adata_out), exist_ok=True)
 
     logger.info(f"Saving AnnData {path_adata_out}...")
     adata_filtered.write(path_adata_out)
 
+
     if create_viz:
         # Create visualization filename based on the AnnData filename
         viz_filename = os.path.splitext(os.path.basename(path_adata_out))[0] + "_dsb_viz.png"
-        viz_output_path = os.path.join(os.path.dirname(path_adata_out), viz_filename)
+        
+        if os.path.dirname(path_adata_out):
+            # If path_adata_out includes a directory, use that
+            viz_output_path = os.path.join(os.path.dirname(path_adata_out), viz_filename)
+        else:
+            # If path_adata_out is just a filename, use the current directory
+            viz_output_path = os.path.join(os.getcwd(), viz_filename)
+        
         logger.info(f"Creating visualization at {viz_output_path}...")
         create_visualization(adata_filtered, viz_output_path)
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser()

--- a/dockers/hto-adt-postprocess/tests/test_dsb.py
+++ b/dockers/hto-adt-postprocess/tests/test_dsb.py
@@ -80,8 +80,7 @@ def test_dsb_adapted_denoising(test_datasets):
     assert not np.array_equal(adata_result_denoised.layers["dsb_normalized"], adata_result_no_denoise.layers["dsb_normalized"]), \
         "Denoised and non-denoised results should be different"
 
-    # Optional: Add more specific checks if needed
-    # For example, you might want to check that the denoised values have lower variance
+    # Check that the denoised values have lower variance
     denoised_variance = np.var(adata_result_denoised.layers["dsb_normalized"])
     non_denoised_variance = np.var(adata_result_no_denoise.layers["dsb_normalized"])
     assert denoised_variance < non_denoised_variance, \

--- a/dockers/hto-adt-postprocess/tests/test_dsb_demux_full_pipeline.py
+++ b/dockers/hto-adt-postprocess/tests/test_dsb_demux_full_pipeline.py
@@ -167,3 +167,27 @@ def test_full_pipeline(test_datasets_with_files, tmp_path):
     assert overall_accuracy > 0.8, f"Overall accuracy is only {overall_accuracy:.2f}"
     
     print(f"Full pipeline test completed successfully. Overall accuracy: {overall_accuracy:.2f}")
+
+def test_incorrect_path(test_datasets_with_files):
+    """
+    Test if output path is given as a file instead of a directory.
+    """
+    filtered_path, raw_path, adata_filtered, adata_raw = test_datasets_with_files
+    
+    dsb_output_path = "dsb_output.h5ad"
+    dsb(
+        path_adata_filtered_in=filtered_path,
+        path_adata_raw_in=raw_path,
+        path_adata_out=dsb_output_path,
+        create_viz=True
+    )
+    
+    # Verify DSB output
+    assert os.path.exists(dsb_output_path), "DSB output file not created"
+    adata_dsb = ad.read_h5ad(dsb_output_path)
+    assert "dsb_normalized" in adata_dsb.layers, "DSB normalized layer not found"
+
+    # Check if visualization file was created
+    viz_filename = os.path.splitext(os.path.basename(dsb_output_path))[0] + "_dsb_viz.png"
+    viz_output_path = os.path.join(os.path.dirname(dsb_output_path), viz_filename)
+    assert os.path.exists(viz_output_path), f"Visualization file not created at {viz_output_path}"


### PR DESCRIPTION
Removed `os.makedirs(os.path.dirname(path_adata_out), exist_ok=True)` since `adata.write()` handles directory creation.
Added test to check if the file/visualization is created when a filename is given as input instead of a directory. If just a filename is given, it'll be written to the current directory. 
Also, set `create_viz` to `False` by default